### PR TITLE
groups join and groups leave

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -25,9 +25,6 @@ class GroupController extends Controller
     {
         $user = $request->user();
         $relations = $request->query('with') ? explode(',', $request->query('with')) : [];
-        $relations[] = 'students';
-        $relations[] = 'teachers';
-        $relations[] = 'skills';
 
         $groups = $user->groups()->with($relations)->filter($request)->paginate($request->query('per_page', 10));
 
@@ -53,5 +50,26 @@ class GroupController extends Controller
         $group->students()->attach($request->student_id);
 
         return response()->json($group, 201);
+    }
+
+    public function addTeacher(Request $request, Group $group)
+    {
+        $group->teachers()->attach($request->teacher_id);
+
+        return response()->json($group, 201);
+    }
+
+    public function joinGroup(Request $request, Group $group)
+    {
+        $group->students()->attach($request->user()->id);
+
+        return response()->json($group, 201);
+    }
+
+    public function leaveGroup(Request $request, Group $group)
+    {
+        $group->students()->detach($request->user()->id);
+
+        return response()->json('You have left the group', 200);
     }
 }

--- a/app/Http/Resources/GroupResource.php
+++ b/app/Http/Resources/GroupResource.php
@@ -17,6 +17,7 @@ class GroupResource extends JsonResource
             'skills' => SkillResource::collection($this->whenLoaded('skills')),
             'students' => UserResource::collection($this->whenLoaded('students')),
             'teachers' => UserResource::collection($this->whenLoaded('teachers')),
+            'students_count' => $this->students? $this->students->count() : 0,
         ];
     }
 }


### PR DESCRIPTION
This pull request includes several enhancements and refactoring to the `GroupController` and `GroupResource` classes. The changes focus on improving group management functionality and optimizing data handling.

### Enhancements to Group Management:

* Added new methods `addTeacher`, `joinGroup`, and `leaveGroup` to the `GroupController` to enable teachers to be added to a group, users to join a group, and users to leave a group, respectively.

### Refactoring and Optimization:

* Removed redundant relations (`students`, `teachers`, `skills`) from the `$relations` array in the `mygroups` method of `GroupController`.
* Added `students_count` to the `toArray` method in `GroupResource` to provide the count of students in a group.