### PR TITLE
fix-middlewares

### DIFF
--- a/app/Http/Middleware/EnsureAdmin.php
+++ b/app/Http/Middleware/EnsureAdmin.php
@@ -16,7 +16,7 @@ class EnsureAdmin
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->user()?->hasRole('admin')) {
+        if (!$request->user()?->hasRole('admin')) {
             return response($request->user()?->role->name, 401);
         }
 

--- a/app/Http/Middleware/EnsureHeadTeacher.php
+++ b/app/Http/Middleware/EnsureHeadTeacher.php
@@ -16,8 +16,8 @@ class EnsureHeadTeacher
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->user()?->hasRole('head-teacher')) {
-            return response('Unauthorized', 401);
+        if (!$request->user()?->hasRole('head-teacher')) {
+            return response($request->user()?->role->name, 401);
         }
 
         return $next($request);

--- a/app/Http/Middleware/EnsureStudent.php
+++ b/app/Http/Middleware/EnsureStudent.php
@@ -16,8 +16,8 @@ class EnsureStudent
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->user()?->hasRole('student')) {
-            return response('Unauthorized', 401);
+        if (!$request->user()?->hasRole('student')) {
+            return response($request->user()?->role->name, 401);
         }
 
         return $next($request);

--- a/app/Http/Middleware/EnsureTeacher.php
+++ b/app/Http/Middleware/EnsureTeacher.php
@@ -15,8 +15,8 @@ class EnsureTeacher
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->user()?->hasRole('teacher')) {
-            return response('Unauthorized', 401);
+        if (!$request->user()?->hasRole('teacher')) {
+            return response($request->user()?->role->name, 401);
         }
 
         return $next($request);


### PR DESCRIPTION
This pull request updates the middleware classes to improve the handling of unauthorized access by changing the response message to include the user's role name instead of a generic 'Unauthorized' message. The most important changes include modifications to the `EnsureAdmin`, `EnsureHeadTeacher`, `EnsureStudent`, and `EnsureTeacher` middleware classes.

Changes to middleware classes:

* [`app/Http/Middleware/EnsureAdmin.php`](diffhunk://#diff-c4b8b495be72705e0297624895e921471629933364948220d6ffee7ef1086cfcL19-R19): Changed the condition to check if the user does not have the 'admin' role and updated the response message to include the user's role name.
* [`app/Http/Middleware/EnsureHeadTeacher.php`](diffhunk://#diff-4059726aba4377daae68ec39b8242bdd60ff746912560dcd2dd1d235a1ca54e4L19-R20): Changed the condition to check if the user does not have the 'head-teacher' role and updated the response message to include the user's role name.
* [`app/Http/Middleware/EnsureStudent.php`](diffhunk://#diff-c1a07e4aae235485bc773e5d3263665e75bc3e8e4c6881de37a7e1fbdc48732cL19-R20): Changed the condition to check if the user does not have the 'student' role and updated the response message to include the user's role name.
* [`app/Http/Middleware/EnsureTeacher.php`](diffhunk://#diff-ade8b5fb1536618807ce14905d7b7b9aff917e607ffef3de5baddc84424db36bL18-R19): Changed the condition to check if the user does not have the 'teacher' role and updated the response message to include the user's role name.