### PR TITLE
scoped

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Resources\GroupResource;
 use App\Models\Group;
+use App\Scopes\ActiveScope;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
@@ -13,8 +14,9 @@ class GroupController extends Controller
     {
         $groupsQuery = Group::with($this->with($request))->filter($request);
 
-        if ($request->user()->hasRole('teacher')) {
-            $groupsQuery->scopeArchived($request->query('archived', false));
+        if ($request->user()->hasRole('teacher') && $request->query('is_archived')) {
+            $groupsQuery->withoutGlobalScope(ActiveScope::class)
+                ->whereNotNull('archived_at');
         }
         $groups = $groupsQuery->paginate($request->query('per_page', 10));
 

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -10,7 +10,10 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use App\Scopes\ActiveScope;
 
+#[ScopedBy([ActiveScope::class])]
 class Group extends Model
 {
     use HasFactory, HasUuids, PopulatesIfEmpty, SoftDeletes;
@@ -21,6 +24,7 @@ class Group extends Model
         'title',
         'desc',
         'overview',
+        'archived_at',
     ];
 
     protected $hidden = [
@@ -34,6 +38,7 @@ class Group extends Model
             'deleted_at' => 'datetime',
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
+            'archived_at' => 'datetime',
         ];
     }
 
@@ -46,7 +51,6 @@ class Group extends Model
     {
         return (new GroupFilter($request))->filter($query);
     }
-
     public function members()
     {
         return $this->belongsToMany(User::class, 'group_members', 'group_id', 'user_id');

--- a/app/Scopes/ActiveScope.php
+++ b/app/Scopes/ActiveScope.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ActiveScope implements Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     */
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('archived_at', null);
+    }
+}

--- a/database/migrations/2024_12_18_094507_add_archived_at_to_groups_table.php
+++ b/database/migrations/2024_12_18_094507_add_archived_at_to_groups_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->timestamp('archived_at')->nullable()->after('desc');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropColumn('archived_at');
+        });
+    }
+};


### PR DESCRIPTION
This pull request introduces changes to support the archiving of groups. The most important changes include adding the `archived_at` column to the `groups` table, implementing a global scope to filter active groups, and modifying the `GroupController` to handle archived groups for teachers.

### Database Changes:
* [`database/migrations/2024_12_18_094507_add_archived_at_to_groups_table.php`](diffhunk://#diff-1c2de2f94dfc24f54f1bac6f2d6e66b3e2b8335ee66370747dd438e0b906b270R1-R28): Added a new migration to include the `archived_at` column in the `groups` table.

### Model Changes:
* [`app/Models/Group.php`](diffhunk://#diff-f425e7fcff8763ffe0306e8f3729063605763ea0a48506510f4bb56ec2117e52R13-R16): Added the `archived_at` attribute, included the `ActiveScope` global scope, and updated the casts array to include `archived_at`. [[1]](diffhunk://#diff-f425e7fcff8763ffe0306e8f3729063605763ea0a48506510f4bb56ec2117e52R13-R16) [[2]](diffhunk://#diff-f425e7fcff8763ffe0306e8f3729063605763ea0a48506510f4bb56ec2117e52R27) [[3]](diffhunk://#diff-f425e7fcff8763ffe0306e8f3729063605763ea0a48506510f4bb56ec2117e52R41)

### Scope Implementation:
* [`app/Scopes/ActiveScope.php`](diffhunk://#diff-9ae313f493ae4365f71acd8c5c21c8e968467e1fa7728f807c0a2e2ea0d6ba42R1-R18): Implemented the `ActiveScope` class to filter out archived groups by default.

### Controller Changes:
* [`app/Http/Controllers/GroupController.php`](diffhunk://#diff-9f1ee62b568d9daf8aaf8eaf29f01a6c45c03df468dafcd5b300c08aa733326bL16-R19): Updated the `index` method to allow teachers to view archived groups by removing the `ActiveScope` when the `is_archived` query parameter is present.